### PR TITLE
[REWORK] Read comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,32 @@
 # RageIB
 
-Rage Instructional Button. is a standalone Instructional Button for FiveM.
+Rage Instructional Button is a standalone Instructional Button API for FiveM.
 
-
+## Lua Example
 ```lua
-local object = UIInstructionalButton.__constructor()
 Citizen.CreateThread(function()
+    local object = UIInstructionalButton.New()
+    object:Refresh() -- call this even after the creation of the object
+    object:Visible(true) -- set the object visibility
+
+    RegisterCommand("background", function()
+        object:UpdateBackground(255, 100, 0, 80) -- upgrade the background based on r, g, b, a parameters you will pass
+        object:Refresh() -- refresh the game part if you changed some data
+    end)
+
+    RegisterCommand("example", function()
+        for i = 1, 300, 1 do
+            object:Add(tostring(i), i) -- add a button to the object based on name and control id
+        end
+
+        object:Refresh()
+    end)
+
     while true do
-        Citizen.Wait(1.0)
-        object:onTick()
+        object:Draw() -- draw the ui you need this or it will not show anything
+        Citizen.Wait(0)
     end
 end)
-
-RegisterCommand("background", function()
-    object:UpdateBackground(255, 100, 0, 80)
-end)
-
-RegisterCommand("example", function()
-    for i = 1, 300 do
-        object:Add(tostring(i), i)
-        Citizen.Wait(50)
-    end
-    object:Visible(true)
-end)
-
-AddEventHandler('onResourceStart', function(resourceName)
-    if (GetCurrentResourceName() ~= resourceName) then
-        return
-    end
-    object:onRefresh()
-end)
-
 ```
+
 <a href="https://ibb.co/sbT0ZZX"><img src="https://i.ibb.co/QpW244x/unknown.png" alt="unknown" border="0"></a>

--- a/client.lua
+++ b/client.lua
@@ -92,11 +92,13 @@ function UIInstructionalButton:Refresh()
     EndScaleformMovieMethod()
 
     for i = 1, #self.items, 1 do
-        BeginScaleformMovieMethod(self.scaleform, "SET_DATA_SLOT")
-        ScaleformMovieMethodAddParamInt(i)
-        ScaleformMovieMethodAddParamPlayerNameString(GetControlInstructionalButton(0, self.items[i].control, true))
-        ScaleformMovieMethodAddParamTextureNameString(self.items[i].name)
-        EndScaleformMovieMethod()
+        if self.items[i] then
+            BeginScaleformMovieMethod(self.scaleform, "SET_DATA_SLOT")
+            ScaleformMovieMethodAddParamInt(i)
+            ScaleformMovieMethodAddParamPlayerNameString(GetControlInstructionalButton(0, self.items[i].control, true))
+            ScaleformMovieMethodAddParamTextureNameString(self.items[i].name)
+            EndScaleformMovieMethod()
+        end
     end
 
     BeginScaleformMovieMethod(self.scaleform, "DRAW_INSTRUCTIONAL_BUTTONS")

--- a/client.lua
+++ b/client.lua
@@ -3,24 +3,25 @@
 --- Created by iTexZ.
 --- DateTime: 04/06/2020 18:39
 ---
-UIInstructionalButton = setmetatable({}, UIInstructionalButton);
+UIInstructionalButton = {}
+local __instance = { __index = UIInstructionalButton }
 
----@type table
-UIInstructionalButton.__index = UIInstructionalButton
-
----__constructor
+---New
 ---@param scaleform string
 ---@return table
 ---@public
-function UIInstructionalButton.__constructor(scaleform)
-    local _UIInstructionalButton = {
+function UIInstructionalButton.New(scaleform)
+    local self = {
         scaleform = RequestScaleformMovie(scaleform or "INSTRUCTIONAL_BUTTONS"),
         display = false,
         color = { r = 0, g = 0, b = 0, a = 80 },
-        items = {};
+        items = {}
     }
-    return setmetatable(_UIInstructionalButton, UIInstructionalButton);
+    
+    return setmetatable(self, __instance)
 end
+
+UIInstructionalButton.__constructor = UIInstructionalButton.New -- compatibility
 
 ---Add
 ---@param name string
@@ -29,8 +30,24 @@ end
 ---@public
 function UIInstructionalButton:Add(name, control)
     self.items[#self.items + 1] = { name = name, control = control }
-    self:onRefresh();
 end
+
+---Remove
+---@param name string
+---@param control number
+---@return void
+---@public
+function UIInstructionalButton:Remove(name, control)
+    for i = 1, #self.items, 1 do
+        if self.items[i] then
+            if (name == nil or (self.items[i].name == name)) and (control == nil or (self.items[i].control == control)) then
+                self.items[i] = nil
+            end
+        end
+    end
+end
+
+UIInstructionalButton.Delete = UIInstructionalButton.Remove -- compatibility
 
 ---UpdateBackground
 ---@param r number
@@ -40,25 +57,8 @@ end
 ---@return table
 ---@public
 function UIInstructionalButton:UpdateBackground(r, g, b, a)
-    self.color = { r = r, g = g, b = b, a = a };
-    self:onRefresh();
+    self.color = { r = r, g = g, b = b, a = a }
     return self.color
-end
-
----Delete
----@param name string
----@param control number
----@return void
----@public
-function UIInstructionalButton:Delete(name, control)
-    for key, value in pairs(self.items) do
-        if (value.name == name) and (control == nil) then
-            self.items[key] = nil;
-        elseif (value.name == name) and (value.control == control) then
-            self.items[key] = nil;
-        end
-    end
-    self:onRefresh();
 end
 
 ---Visible
@@ -66,48 +66,52 @@ end
 ---@return boolean
 ---@public
 function UIInstructionalButton:Visible(bool)
-    self.display = bool;
-    return self.display;
+    self.display = bool
+    return self.display
 end
 
----onRefresh
+---Refresh
 ---@return void
 ---@private
-function UIInstructionalButton:onRefresh()
-    PushScaleformMovieFunction(self.scaleform, "CLEAR_ALL")
-    PopScaleformMovieFunction()
+function UIInstructionalButton:Refresh()
+    BeginScaleformMovieMethod(self.scaleform, "CLEAR_ALL")
+    EndScaleformMovieMethod()
 
-    PushScaleformMovieFunction(self.scaleform, "TOGGLE_MOUSE_BUTTONS")
-    PushScaleformMovieFunctionParameterInt(0)
-    PopScaleformMovieFunction()
+    BeginScaleformMovieMethod(self.scaleform, "TOGGLE_MOUSE_BUTTONS")
+    ScaleformMovieMethodAddParamInt(0)
+    EndScaleformMovieMethod()
 
-    PushScaleformMovieFunction(self.scaleform, "SET_BACKGROUND_COLOUR")
-    PushScaleformMovieFunctionParameterInt(self.color.r)
-    PushScaleformMovieFunctionParameterInt(self.color.g)
-    PushScaleformMovieFunctionParameterInt(self.color.b)
-    PushScaleformMovieFunctionParameterInt(self.color.a)
-    PopScaleformMovieFunction()
+    BeginScaleformMovieMethod(self.scaleform, "SET_BACKGROUND_COLOUR")
+    ScaleformMovieMethodAddParamInt(self.color.r)
+    ScaleformMovieMethodAddParamInt(self.color.g)
+    ScaleformMovieMethodAddParamInt(self.color.b)
+    ScaleformMovieMethodAddParamInt(self.color.a)
+    EndScaleformMovieMethod()
 
     PushScaleformMovieFunction(self.scaleform, "CREATE_CONTAINER")
-    PopScaleformMovieFunction()
+    EndScaleformMovieMethod()
 
-    for key, value in pairs(self.items) do
-        PushScaleformMovieFunction(self.scaleform, "SET_DATA_SLOT")
-        PushScaleformMovieFunctionParameterInt(key)
-        PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(1, value.control, 0))
-        PushScaleformMovieFunctionParameterString(value.name)
-        PopScaleformMovieFunction()
+    for i = 1, #self.items, 1 do
+        BeginScaleformMovieMethod(self.scaleform, "SET_DATA_SLOT")
+        ScaleformMovieMethodAddParamInt(i)
+        ScaleformMovieMethodAddParamPlayerNameString(GetControlInstructionalButton(0, self.items[i].control, true))
+        ScaleformMovieMethodAddParamTextureNameString(self.items[i].name)
+        EndScaleformMovieMethod()
     end
 
-    PushScaleformMovieFunction(self.scaleform, "DRAW_INSTRUCTIONAL_BUTTONS")
-    PushScaleformMovieFunctionParameterInt(-1)
-    PopScaleformMovieFunction()
+    BeginScaleformMovieMethod(self.scaleform, "DRAW_INSTRUCTIONAL_BUTTONS")
+    ScaleformMovieMethodAddParamInt(-1)
+    EndScaleformMovieMethod()
 end
 
----onTick
+UIInstructionalButton.onRefresh = UIInstructionalButton.Refresh -- compatibility
+
+---Draw
 ---@return void
-function UIInstructionalButton:onTick()
+function UIInstructionalButton:Draw()
     if (#self.items > 0) and (self.display) then
         DrawScaleformMovieFullscreen(self.scaleform, 255, 255, 255, 255)
     end
 end
+
+UIInstructionalButton.onTick = UIInstructionalButton.Draw -- compatibility


### PR DESCRIPTION
Hello

here are the list of things updated & why i updated them
- the __constructor name is not proper name in this case don't take esx v2 names as example
- Refresh function is better when controlled totally by the client so you don't hardcode the refresh in case user want to manually refresh
- onTick is not a proper name i think Draw should be better for new users
- fixed use of pairs() in this case it's not necessary (because the table number is managed by the "n" key that table.insert interact set) and pairs is 2 times more heavy than for i=1 way
- renamed UIInstructionalButton.Delete to Remove cause the contrary is Add and not Create and Add makes more sense in this case that's why i didn't renamed UIInstructionalButton:Add function to Create
- modified Remove function so the "filters" parameters are additionnal in case you want to Remove all items or if you want to pass filter based on control
- renamed natives to the new ones & updated parameters passed to it based on the fivem docs
- reworked how work the instance creation in .New function
- removed all ; cause it just take useless bytes
- every old functions name has been kept as alias for backwards compatibility
- readme updated regarding the new function name